### PR TITLE
fix(cycle-scripts-es-browserify): Fix the test script

### DIFF
--- a/cycle-scripts-es-browserify/scripts/test.js
+++ b/cycle-scripts-es-browserify/scripts/test.js
@@ -11,7 +11,7 @@ var args = [
   '--require',
   'babel-register',
   !process.env.CI && (console.log(chalk.green.bold('Enabling watch mode')) || '--watch'),
-  '**/*.test.js'
+  'src/**/*.test.js'
 ].filter(Boolean)
 
 spawn(mocha, args, {stdio: 'inherit'})


### PR DESCRIPTION
Test were broken for `cycle-scripts-es-browserify`. 
Running `npm test`  was trowing an error as mocha was searching for test files within the node_modules directory. 

Similar to [this](https://github.com/cyclejs-community/create-cycle-app/pull/1/commits/f9dc18a797b11a45e937392047bbaf02f291f291)