### PR TITLE
fix(cycle-scripts-ts-webpack): fix build failing with Typescript 2.1

### DIFF
--- a/cycle-scripts-ts-webpack/package.json
+++ b/cycle-scripts-ts-webpack/package.json
@@ -22,7 +22,7 @@
     "@types/core-js": "^0.9.34",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.45",
-    "awesome-typescript-loader": "^2.2.4",
+    "awesome-typescript-loader": "^3.0.0-beta",
     "chalk": "^1.1.3",
     "cross-spawn": "^4.0.2",
     "fs-extra": "^0.30.0",

--- a/cycle-scripts-ts-webpack/scripts/build.js
+++ b/cycle-scripts-ts-webpack/scripts/build.js
@@ -5,6 +5,7 @@ var path = require('path')
 var mkdirp = require('mkdirp')
 var webpack = require('webpack')
 var ProgressBarPlugin = require('progress-bar-webpack-plugin')
+var { CheckerPlugin } = require('awesome-typescript-loader')
 
 var buildPath = path.join(process.cwd(), 'build')
 var publicPath = path.join(process.cwd(), 'public')
@@ -32,7 +33,8 @@ var compiler = webpack({
   },
   plugins: [
     new ProgressBarPlugin(),
-    new webpack.optimize.UglifyJsPlugin({minimize: true})
+    new webpack.optimize.UglifyJsPlugin({minimize: true}),
+    new CheckerPlugin()
   ]
 })
 

--- a/cycle-scripts-ts-webpack/scripts/start.js
+++ b/cycle-scripts-ts-webpack/scripts/start.js
@@ -3,6 +3,7 @@
 var webpack = require('webpack')
 var WebpackDevServer = require('webpack-dev-server')
 var ProgressBarPlugin = require('progress-bar-webpack-plugin')
+var { CheckerPlugin } = require('awesome-typescript-loader')
 
 var host = 'http://localhost'
 var port = 8000
@@ -31,7 +32,8 @@ var config = {
   devtool: 'source-map',
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
-    new ProgressBarPlugin()
+    new ProgressBarPlugin(),
+    new CheckerPlugin()
   ]
 }
 


### PR DESCRIPTION
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`
- [x] I have rebased my branch onto master before merging

ISSUES CLOSED: #49
@geovanisouza92: while updating dependencies, I also found webpack complaining about missing the 'CheckerPlugin' that comes packed with 'awesome-typescript-loader'. I've updated `start` and `build` webpack configs accordingly.

