### PR TITLE
Enable devServer port to customize

### DIFF
--- a/packages/cycle-scripts/configs/webpackDevServer.config.js
+++ b/packages/cycle-scripts/configs/webpackDevServer.config.js
@@ -37,6 +37,7 @@ const path = require('path')
 
 const protocol = process.env.HTTPS === 'true' ? 'https' : 'http'
 const host = process.env.HOST || 'localhost'
+const port = process.env.PORT || 8000
 
 const appDirectory = fs.realpathSync(process.cwd())
 function resolveApp (relativePath) {
@@ -44,7 +45,7 @@ function resolveApp (relativePath) {
 }
 
 module.exports = {
-  port: 8000, // tofix
+  port,
   // Enable gzip compression of generated files.
   compress: true,
   // Silence WebpackDevServer's own logs since they're generally not useful.


### PR DESCRIPTION
<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] I ran `npm test` for the package I'm modifying
> But something goes wrong! And I think that is not my fault…I don't know why
- [x] I used `npm run commit` instead of `git commit`
> I can't find this command…
- [x] I have rebased my branch onto master before merging

Enable devServer port to customize. We can use `PORT=xxxx npm start` to run our app in a customized port.
